### PR TITLE
Update renderMotion for opacity and simplify checks

### DIFF
--- a/NavigationReactNativeWeb/src/NavigationStack.tsx
+++ b/NavigationReactNativeWeb/src/NavigationStack.tsx
@@ -54,17 +54,18 @@ const NavigationStack = ({unmountedStyle, mountedStyle, crumbedStyle, unmountSty
   );
 }
 
-const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc}, scene, key) => (
+const renderMotion = ({translateX, translateX_pc, scaleX, scaleX_pc, alpha}, scene, key) => (
   <View key={key}
     style={{
       transform: `
-        translate(${translateX ? `${translateX}px` : translateX_pc ? `${translateX_pc}%` : '0'})
-        scale(${scaleX !== 1 ? `${scaleX}` : scaleX_pc ? `${scaleX_pc / 100}` : '1'})
+        translate(${translateX ? `${translateX}px` : `${translateX_pc}%`})
+        scale(${scaleX !== 1 ? `${scaleX}` : `${scaleX_pc / 100}`})
       ` as any,
       position: 'absolute',
       backgroundColor: '#fff',
       left: 0, right: 0, top: 0, bottom: 0,
       overflow: 'hidden',
+      opacity: alpha,
     }}>
     {scene}
   </View>


### PR DESCRIPTION
Add `alpha` prop to `renderMotion` for parent `View` opacity and remove unnecessary null checks for `translateX_pc` and `scaleX_pc`.

---
<a href="https://cursor.com/background-agent?bcId=bc-acc7f66c-266a-464d-802b-89f47620c1c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-acc7f66c-266a-464d-802b-89f47620c1c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

